### PR TITLE
removed fallbackToDestructiveMigration for room

### DIFF
--- a/dndCalendar/impl/src/main/java/com/suit/dndCalendar/impl/koin/KoinModule.kt
+++ b/dndCalendar/impl/src/main/java/com/suit/dndCalendar/impl/koin/KoinModule.kt
@@ -33,7 +33,6 @@ val dndCalendarImplKoinModule = module {
                 UpcomingEventsDb::class.java,
                 "upcoming-events-db"
             )
-                .fallbackToDestructiveMigration()
                 .build()
         )
     }
@@ -43,7 +42,7 @@ val dndCalendarImplKoinModule = module {
                 androidContext(),
                 DNDScheduleCalendarCriteriaDb::class.java,
                 "dnd-schedule-calendar-db"
-            ).fallbackToDestructiveMigration()
+            )
                 .build()
         )
     }


### PR DESCRIPTION
Schema path is already provided. Automatic or manual migrations could be applied in the future