### PR TITLE
Fix/overlap protection

### DIFF
--- a/dndCalendar/impl/src/main/java/com/suit/dndCalendar/impl/data/DNDCalendarSchedulerImpl.kt
+++ b/dndCalendar/impl/src/main/java/com/suit/dndCalendar/impl/data/DNDCalendarSchedulerImpl.kt
@@ -235,7 +235,7 @@ internal class DNDCalendarSchedulerImpl(
     }
 
     // checks if current event's end time is equal to another event's start time
-    // returns true if no overlapping happens
+    // returns false if no overlapping happens
     private fun doesOverlap(endTime: Long): Boolean {
         val projection = arrayOf(
             CalendarContract.Events.DTSTART


### PR DESCRIPTION
Fixed an overlap issue where one event's end time is equal to another event's start time, resulting in dnd toggle being executed almost at the same time and resulting in race condition.

![image](https://github.com/user-attachments/assets/4d5de60f-b1bb-4f64-8a7b-c150966babb9)

Now dnd won't be turned off for that first event.